### PR TITLE
fix weighed edit distance

### DIFF
--- a/ex2-eddist/edit-distance.ipynb
+++ b/ex2-eddist/edit-distance.ipynb
@@ -41,7 +41,7 @@
     "    ('their', 'they', 2, 2.5, '___is'),\n",
     "    ('they', 'their', 2, 2.5, '___ds'),\n",
     "    ('they', 'their', 2, 2.5, '___ds'),\n",
-    "    ('they', 'they re', 3, 3.0, '____ddd'),\n",
+    "    ('they', 'they re', 3, 2.5, '____ddd'),\n",
     "    ('poorbob', 'alice', 7, 8.2, 'iisssss'),\n",
     "]"
    ]


### PR DESCRIPTION
Cost of space insertion/deletion is only 0.5, therefore weighed edit distance of `they` and `they re` should be 2.5